### PR TITLE
Extend for multi tenant project

### DIFF
--- a/passkeys/FIDO2.py
+++ b/passkeys/FIDO2.py
@@ -11,15 +11,16 @@ from fido2.webauthn import PublicKeyCredentialRpEntity, AttestedCredentialData, 
 from .models import UserPasskey
 from user_agents.parsers import parse as ua_parse
 
+
 def enable_json_mapping():
     try:
         fido2.features.webauthn_json_mapping.enabled = True
     except:
         pass
 
+
 def getUserCredentials(user):
     return [AttestedCredentialData(websafe_decode(uk.token)) for uk in UserPasskey.objects.filter(user = user)]
-
 
 
 def getServer():
@@ -36,6 +37,7 @@ def getServer():
 
     rp = PublicKeyCredentialRpEntity(id=fido_server_id, name=fido_server_name)
     return Fido2Server(rp)
+
 
 def get_current_platform(request):
     ua = ua_parse(request.META["HTTP_USER_AGENT"])
@@ -92,11 +94,6 @@ def reg_complete(request):
         return JsonResponse({'status': 'ERR', "message": "Error on server, please try again later"})
 
 
-
-
-
-
-
 def auth_begin(request):
     enable_json_mapping()
     server = getServer()
@@ -111,7 +108,6 @@ def auth_begin(request):
     auth_data, state = server.authenticate_begin(credentials)
     request.session['fido2_state'] = state
     return JsonResponse(dict(auth_data))
-
 
 
 @csrf_exempt

--- a/passkeys/FIDO2.py
+++ b/passkeys/FIDO2.py
@@ -55,7 +55,7 @@ def get_current_platform(request):
 def reg_begin(request):
     """Starts registering a new FIDO Device, called from API"""
     enable_json_mapping()
-    server = getServer()
+    server = getServer(request)
     auth_attachment = getattr(settings,'KEY_ATTACHMENT', None)
     registration_data, state = server.register_begin({
         u'id': request.user.username.encode("utf8"),
@@ -76,7 +76,7 @@ def reg_complete(request):
         enable_json_mapping()
         data = json.loads(request.body)
         name = data.pop("key_name",'')
-        server = getServer()
+        server = getServer(request)
         auth_data = server.register_complete(request.session.pop("fido2_state"), response = data)
         encoded = websafe_encode(auth_data.credential_data)
         platform = get_current_platform(request)
@@ -96,7 +96,7 @@ def reg_complete(request):
 
 def auth_begin(request):
     enable_json_mapping()
-    server = getServer()
+    server = getServer(request)
     credentials=[]
     username = None
     if "base_username" in request.session:
@@ -114,7 +114,7 @@ def auth_begin(request):
 def auth_complete(request):
     enable_json_mapping()
     credentials = []
-    server = getServer()
+    server = getServer(request)
     data = json.loads(request.POST["passkeys"])
     key = None
     #userHandle = data.get("response",{}).get('userHandle')

--- a/passkeys/FIDO2.py
+++ b/passkeys/FIDO2.py
@@ -24,7 +24,17 @@ def getUserCredentials(user):
 
 def getServer():
     """Get Server Info from settings and returns a Fido2Server"""
-    rp = PublicKeyCredentialRpEntity(id=settings.FIDO_SERVER_ID, name=settings.FIDO_SERVER_NAME)
+    if callable(settings.FIDO_SERVER_ID):
+        fido_server_id = settings.FIDO_SERVER_ID()
+    else:
+        fido_server_id = settings.FIDO_SERVER_ID
+
+    if callable(settings.FIDO_SERVER_NAME):
+        fido_server_name = settings.FIDO_SERVER_NAME()
+    else:
+        fido_server_name = settings.FIDO_SERVER_NAME
+
+    rp = PublicKeyCredentialRpEntity(id=fido_server_id, name=fido_server_name)
     return Fido2Server(rp)
 
 def get_current_platform(request):

--- a/passkeys/FIDO2.py
+++ b/passkeys/FIDO2.py
@@ -23,15 +23,15 @@ def getUserCredentials(user):
     return [AttestedCredentialData(websafe_decode(uk.token)) for uk in UserPasskey.objects.filter(user = user)]
 
 
-def getServer():
+def getServer(request=None):
     """Get Server Info from settings and returns a Fido2Server"""
     if callable(settings.FIDO_SERVER_ID):
-        fido_server_id = settings.FIDO_SERVER_ID()
+        fido_server_id = settings.FIDO_SERVER_ID(request)
     else:
         fido_server_id = settings.FIDO_SERVER_ID
 
     if callable(settings.FIDO_SERVER_NAME):
-        fido_server_name = settings.FIDO_SERVER_NAME()
+        fido_server_name = settings.FIDO_SERVER_NAME(request)
     else:
         fido_server_name = settings.FIDO_SERVER_NAME
 


### PR DESCRIPTION
To use Django-passkeys in a multi tenant project, the FIDO_SERVER_ID and FIDO_SERVER_NAME cannot be hard coded in the settings, but must be retrieved via a callable.

Changes:
- Callable  FIDO_SERVER_ID and FIDO_SERVER_NAME
- For calls to getServer(): pass Django request as argument, to be able to extract server ID from request
- "black" code cleaning: 2 empty lines before function definition