### PR TITLE
Avoid hard-coding the username field name

### DIFF
--- a/passkeys/FIDO2.py
+++ b/passkeys/FIDO2.py
@@ -104,9 +104,9 @@ def auth_begin(request):
     if "base_username" in request.session:
         username = request.session["base_username"]
     if request.user.is_authenticated:
-        username = request.user.username
+        username = request.user.get_username()
     if username:
-        credentials = getUserCredentials(request.session.get("base_username", request.user.username))
+        credentials = getUserCredentials(request.session.get("base_username", request.user.get_username()))
     auth_data, state = server.authenticate_begin(credentials)
     request.session['fido2_state'] = state
     return JsonResponse(dict(auth_data))

--- a/passkeys/FIDO2.py
+++ b/passkeys/FIDO2.py
@@ -58,10 +58,11 @@ def reg_begin(request):
     enable_json_mapping()
     server = getServer(request)
     auth_attachment = getattr(settings,'KEY_ATTACHMENT', None)
+    username = request.user.get_username()
     registration_data, state = server.register_begin({
-        u'id':  urlsafe_b64encode(request.user.username.encode("utf8")),
-        u'name': request.user.username,
-        u'displayName': request.user.username,
+        u'id':  urlsafe_b64encode(username.encode("utf8")),
+        u'name': username,
+        u'displayName': username,
     }, getUserCredentials(request.user), authenticator_attachment = auth_attachment, resident_key_requirement=fido2.webauthn.ResidentKeyRequirement.PREFERRED)
     request.session['fido2_state'] = state
     return JsonResponse(dict(registration_data))


### PR DESCRIPTION
* Avoid hard-coding the username field name. (a35f011)

    This is provided by Django's AbstractBaseUser class, which allows setting a different field name using USERNAME_FIELD.

* Use the Django helper to get the username. (8ddc993)

    I'm not entirely sure when the base username is set in the session, but this should have the same behaviour as before, but without hard-coding the username field name.
