### PR TITLE
Update helpers.js to fix Software Keys

### DIFF
--- a/passkeys/static/passkeys/js/helpers.js
+++ b/passkeys/static/passkeys/js/helpers.js
@@ -1,4 +1,9 @@
 var publicKeyCredentialToJSON = (pubKeyCred) => {
+
+            if(pubKeyCred instanceof Uint8Array){
+                return base64url.encode(pubKeyCred.buffer);
+            }
+            
             if(pubKeyCred instanceof Array) {
                 let arr = [];
                 for(let i of pubKeyCred)


### PR DESCRIPTION
Cast Uint8Array objects to base64url encoding when preparing the payload so fido2 knows how to process it.

In newer versions of the credential creation function, some software passkeys will return Uint8Array objects where hardware tokens would pass base64 objects for elements like response.clientDataJSON and response.attestationObject.

This would result in those elements being casted as objects which would then fail out when running AuthenticationResponse.from_dict(response) in any of the views trying to process it due to a type where we pass it dict instead of the expected bytes.