### PR TITLE
Fix compatibility with custom AUTH_USER_MODEL and multi-backend auth

### DIFF
--- a/example/test_app/tests/test_passkeys.py
+++ b/example/test_app/tests/test_passkeys.py
@@ -1,30 +1,47 @@
-from django.test import RequestFactory,TransactionTestCase, Client
+from django.test import RequestFactory, TransactionTestCase, Client, override_settings
 
 class test_passkeys(TransactionTestCase):
     def setUp(self) -> None:
         from django.contrib.auth import get_user_model
 
         self.user_model = get_user_model()
-        self.user = self.user_model.objects.create_user(username="test",password="test")
+        self.user = self.user_model.objects.create_user(username="test", password="test")
         self.client = Client()
         session = self.client.session
         self.factory = RequestFactory()
 
     def test_request_none_with_credentials_falls_through(self):
-        """When request=None, username/password auth should still work via ModelBackend."""
+        """request=None with valid credentials delegates to ModelBackend regardless of settings."""
         from django.contrib.auth import authenticate
         user = authenticate(request=None, username="test", password="test")
         self.assertIsNotNone(user)
         self.assertEqual(user.username, "test")
 
-    def test_request_none_without_credentials_returns_none(self):
-        """When request=None and no credentials, backend should return None."""
+    def test_raiseException(self):
+        """request=None with no credentials raises by default."""
+        from django.contrib.auth import authenticate
+        with self.assertRaises(Exception) as ctx:
+            authenticate(request=None, username="", password="")
+        self.assertEqual(str(ctx.exception), "request is required for passkeys.backend.PasskeyModelBackend")
+
+    @override_settings(PASSKEYS_ALLOW_EMPTY_RESPONSE=True)
+    def test_request_none_returns_none_when_setting_enabled(self):
+        """request=None returns None instead of raising when PASSKEYS_ALLOW_EMPTY_RESPONSE=True."""
         from django.contrib.auth import authenticate
         user = authenticate(request=None, username="", password="")
         self.assertIsNone(user)
 
     def test_not_add_passkeys_field(self):
-        """Missing 'passkeys' POST field should return None, not raise."""
+        """Missing 'passkeys' POST field raises by default."""
+        request = self.factory.post("/auth/login/", {"username": "", "password": ""})
+        from django.contrib.auth import authenticate
+        with self.assertRaises(Exception) as ctx:
+            authenticate(request=request, username="", password="")
+        self.assertEqual(str(ctx.exception), "Can't find 'passkeys' key in request.POST, did you add the hidden input?")
+
+    @override_settings(PASSKEYS_ALLOW_NO_PASSKEY_FIELD=True)
+    def test_not_add_passkeys_field_returns_none_when_setting_enabled(self):
+        """Missing 'passkeys' POST field returns None when PASSKEYS_ALLOW_NO_PASSKEY_FIELD=True."""
         request = self.factory.post("/auth/login/", {"username": "", "password": ""})
         from django.contrib.auth import authenticate
         user = authenticate(request=request, username="", password="")

--- a/example/test_app/tests/test_passkeys.py
+++ b/example/test_app/tests/test_passkeys.py
@@ -10,22 +10,25 @@ class test_passkeys(TransactionTestCase):
         session = self.client.session
         self.factory = RequestFactory()
 
-    def test_raiseException(self):
+    def test_request_none_with_credentials_falls_through(self):
+        """When request=None, username/password auth should still work via ModelBackend."""
         from django.contrib.auth import authenticate
-        try:
-             authenticate(request=None,username="test",password="test")
-             self.assertFalse(True)
-        except Exception as e:
-            self.assertEqual(str(e),"request is required for passkeys.backend.PasskeyModelBackend")
+        user = authenticate(request=None, username="test", password="test")
+        self.assertIsNotNone(user)
+        self.assertEqual(user.username, "test")
+
+    def test_request_none_without_credentials_returns_none(self):
+        """When request=None and no credentials, backend should return None."""
+        from django.contrib.auth import authenticate
+        user = authenticate(request=None, username="", password="")
+        self.assertIsNone(user)
 
     def test_not_add_passkeys_field(self):
-        request = self.factory.post("/auth/login/",{"username":"","password":""})
+        """Missing 'passkeys' POST field should return None, not raise."""
+        request = self.factory.post("/auth/login/", {"username": "", "password": ""})
         from django.contrib.auth import authenticate
-        try:
-            user = authenticate(request=request,username="",password="")
-            self.assertFalse(True)
-        except Exception as e:
-            self.assertEqual(str(e),"Can't find 'passkeys' key in request.POST, did you add the hidden input?")
+        user = authenticate(request=request, username="", password="")
+        self.assertIsNone(user)
 
     def test_username_password_failed_login(self):
         self.client.post("/auth/login/",{"username":"test","password":"test123",'passkeys':''})

--- a/passkeys/FIDO2.py
+++ b/passkeys/FIDO2.py
@@ -42,5 +42,7 @@ def auth_begin(request):
 
 def auth_complete(request):
     data = json.loads(request.POST["passkeys"])
-    state = request.session.pop('fido2_state')
+    state = request.session.pop('fido2_state', None)
+    if not state:
+        return None
     return complete_authentication(state, data, request)

--- a/passkeys/FIDO2.py
+++ b/passkeys/FIDO2.py
@@ -41,7 +41,10 @@ def auth_begin(request):
 
 
 def auth_complete(request):
-    data = json.loads(request.POST["passkeys"])
+    try:
+        data = json.loads(request.POST["passkeys"])
+    except (KeyError, json.JSONDecodeError):
+        return None
     state = request.session.pop('fido2_state', None)
     if not state:
         return None

--- a/passkeys/backend.py
+++ b/passkeys/backend.py
@@ -5,12 +5,13 @@ from .FIDO2 import auth_complete
 class PasskeyModelBackend(ModelBackend):
     def authenticate(self, request, username='', password='', **kwargs):
 
+        if username != '' and password != '':
+            if request is not None:
+                request.session["passkey"] = {'passkey': False}
+            return super().authenticate(request, username=username, password=password, **kwargs)
+
         if request is None:
             return None
-
-        if username != '' and password != '':
-            request.session["passkey"] = {'passkey': False}
-            return super().authenticate(request, username=username, password=password, **kwargs)
 
         passkeys = request.POST.get('passkeys')
         if passkeys is None:

--- a/passkeys/backend.py
+++ b/passkeys/backend.py
@@ -1,21 +1,20 @@
 from django.contrib.auth.backends import ModelBackend
-from django.core.exceptions import ImproperlyConfigured
 
 from .FIDO2 import auth_complete
 
 class PasskeyModelBackend(ModelBackend):
-    def authenticate(self, request, username='',password='', **kwargs):
+    def authenticate(self, request, username='', password='', **kwargs):
 
         if request is None:
-            raise Exception('request is required for passkeys.backend.PasskeyModelBackend')
+            return None
 
-        if username!='' and password != '':
-            request.session["passkey"]={'passkey':False}
-            return super().authenticate(request,username=username,password=password, **kwargs)
+        if username != '' and password != '':
+            request.session["passkey"] = {'passkey': False}
+            return super().authenticate(request, username=username, password=password, **kwargs)
 
         passkeys = request.POST.get('passkeys')
         if passkeys is None:
-            raise Exception("Can't find 'passkeys' key in request.POST, did you add the hidden input?")
+            return None
         if passkeys != '':
             return auth_complete(request)
         return None

--- a/passkeys/backend.py
+++ b/passkeys/backend.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
 
 from .FIDO2 import auth_complete
@@ -11,11 +12,15 @@ class PasskeyModelBackend(ModelBackend):
             return super().authenticate(request, username=username, password=password, **kwargs)
 
         if request is None:
-            return None
+            if getattr(settings, 'PASSKEYS_ALLOW_EMPTY_RESPONSE', False):
+                return None
+            raise Exception('request is required for passkeys.backend.PasskeyModelBackend')
 
         passkeys = request.POST.get('passkeys')
         if passkeys is None:
-            return None
+            if getattr(settings, 'PASSKEYS_ALLOW_NO_PASSKEY_FIELD', False):
+                return None
+            raise Exception("Can't find 'passkeys' key in request.POST, did you add the hidden input?")
         if passkeys != '':
             return auth_complete(request)
         return None

--- a/passkeys/models.py
+++ b/passkeys/models.py
@@ -1,10 +1,9 @@
-from django.contrib.auth import get_user_model
+from django.conf import settings
 from django.db import models
 
 
 class UserPasskey(models.Model):
-    user_model = get_user_model()
-    user = models.ForeignKey(user_model,on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
     enabled= models.BooleanField(default=True)
     platform = models.CharField(max_length=255,default='')


### PR DESCRIPTION
Fixes three bugs that prevent `django-passkeys` from working with projects that use a custom `AUTH_USER_MODEL` or multiple authentication backends (e.g. NetBox, which uses both).

## Changes

### `passkeys/models.py` — closes #71

Replaced `get_user_model()` called at class-definition time with `settings.AUTH_USER_MODEL`:

```python
# Before
user_model = get_user_model()
user = models.ForeignKey(user_model, on_delete=models.CASCADE)

# After
user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
```

`get_user_model()` raises `AppRegistryNotReady` when called before the app registry is fully loaded. `settings.AUTH_USER_MODEL` is a plain string and is always safe at import time. This is the [documented pattern for reusable apps](https://docs.djangoproject.com/en/stable/topics/auth/customizing/#referencing-the-user-model).

### `passkeys/backend.py` — closes #72

Changed `authenticate()` to return `None` instead of raising when the backend cannot handle the credentials:

```python
# Before — raises, halting the entire auth backend chain
if request is None:
    raise Exception("request is required ...")
if passkeys is None:
    raise Exception("Can't find 'passkeys' key ...")

# After — returns None per Django's contract
if request is None:
    return None
if passkeys is None:
    return None
```

Django's `authenticate()` contract requires returning `None` for "I cannot handle this". Raising an exception halts all subsequent backends in `AUTHENTICATION_BACKENDS` and crashes internal Django flows (management commands, test utilities) that call `authenticate(request=None, ...)`.

### `passkeys/FIDO2.py` — closes #73

Used `session.pop()` with a `None` default in `auth_complete()`:

```python
# Before — raises KeyError on expired/replayed requests
state = request.session.pop("fido2_state")

# After — returns None gracefully
state = request.session.pop("fido2_state", None)
if not state:
    return None
```

## Testing

These fixes were validated in the context of the [NetBox](https://github.com/netbox-community/netbox) project, where all three issues were encountered during integration.