### PR TITLE
fix(passkeys): get actual identifier field (e.g. email) instead of username, to allow for custom user models

### DIFF
--- a/passkeys/backend.py
+++ b/passkeys/backend.py
@@ -9,12 +9,13 @@ identifier_field = UserModel.USERNAME_FIELD
 
 
 class PasskeyModelBackend(ModelBackend):
-    def authenticate(self, request, username='', password='', **kwargs):
+    def authenticate(self, request, username=None, password=None, **kwargs):
         # get actual identifier field (e.g. email) instead of username, to allow for custom user models
         identifier = username or kwargs.get(identifier_field)
-        if identifier != '' and password != '':
+        if identifier and password:
             if request is not None:
                 request.session["passkey"] = {'passkey': False}
+
             return super().authenticate(request, username=username, password=password, **kwargs)
 
         if request is None:

--- a/passkeys/backend.py
+++ b/passkeys/backend.py
@@ -1,12 +1,18 @@
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 
 from .FIDO2 import auth_complete
 
+UserModel = get_user_model()
+identifier_field = UserModel.USERNAME_FIELD
+
+
 class PasskeyModelBackend(ModelBackend):
     def authenticate(self, request, username='', password='', **kwargs):
-
-        if username != '' and password != '':
+        # get actual identifier field (e.g. email) instead of username, to allow for custom user models
+        identifier = username or kwargs.get(identifier_field)
+        if identifier != '' and password != '':
             if request is not None:
                 request.session["passkey"] = {'passkey': False}
             return super().authenticate(request, username=username, password=password, **kwargs)


### PR DESCRIPTION
Fixed authentication backend crash when using custom username fields (e.g. email or phone). The backend now safely handles requests without the `passkeys` field and works correctly with any configured `USERNAME_FIELD`, avoiding exceptions during standard login flows. Additionally, `username` is passed as `None` when not provided to prevent unintended behavior in `ModelBackend.authenticate`.

https://github.com/django/django/blob/50bbf71bbd51616e2ce48785336ca3746fbe5f24/django/contrib/auth/backends.py#L66
